### PR TITLE
отработка  пропуска отметки

### DIFF
--- a/bindpy/CMakeLists.txt
+++ b/bindpy/CMakeLists.txt
@@ -4,6 +4,7 @@ pybind11_add_module(${PROJECT_NAME}
     MODULE
         bind_ukf.cpp
         bind_ekf.cpp
+        bind_track.cpp
         bindings.cpp
         )
 

--- a/bindpy/bind_track.cpp
+++ b/bindpy/bind_track.cpp
@@ -4,12 +4,16 @@ namespace py = pybind11;
 class BindTrackUkf
 {
 private:
-    Track <Eigen::MatrixXd, UnscentedKalmanfilter<Eigen::MatrixXd, FuncConstVel, FuncMeasSph>> track;
-    
+    Track<Eigen::MatrixXd, UnscentedKalmanfilter<Eigen::MatrixXd, FuncConstVel, FuncMeasSph>> track;
 
-public :
+public:
+    BindTrackUkf(Eigen::MatrixXd state,
+                 double t,
+                 Eigen::MatrixXd processNoise,
+                 Eigen::MatrixXd measureNoise,
+                 double k) : track(state, t, processNoise, measureNoise, k) {}
 
-    Eigen::MatrixXd step(Eigen::MatrixXd& meas)
+    Eigen::MatrixXd step(Eigen::MatrixXd &meas)
     {
         return track.Step(meas);
     }
@@ -18,14 +22,12 @@ public :
     {
         return track.Step(dt);
     }
-
 };
 
 void bind_track(pybind11::module &m)
 {
-    py::class_<BindTrackUkf>(m, "BindTrack")
-        .def(py::init<>())
-        .def("step",(Eigen::MatrixXd(BindTrackUkf::*)(Eigen::MatrixXd&)) &BindTrackUkf::step)
-        .def("step",(Eigen::MatrixXd(BindTrackUkf::*)(double)) &BindTrackUkf::step);
-        
+    py::class_<BindTrackUkf>(m, "BindTrackUkf")
+        .def(py::init<const Eigen::MatrixXd&, double, const Eigen::MatrixXd&, const Eigen::MatrixXd&, double>())
+        .def("step", (Eigen::MatrixXd(BindTrackUkf::*)(Eigen::MatrixXd &)) & BindTrackUkf::step)
+        .def("step", (Eigen::MatrixXd(BindTrackUkf::*)(double)) & BindTrackUkf::step);
 }

--- a/bindpy/bind_track.cpp
+++ b/bindpy/bind_track.cpp
@@ -1,0 +1,31 @@
+#include "bind_track.h"
+namespace py = pybind11;
+
+class BindTrackUkf
+{
+private:
+    Track <Eigen::MatrixXd, UnscentedKalmanfilter<Eigen::MatrixXd, FuncConstVel, FuncMeasSph>> track;
+    
+
+public :
+
+    Eigen::MatrixXd step(Eigen::MatrixXd& meas)
+    {
+        return track.Step(meas);
+    }
+
+    Eigen::MatrixXd step(double dt)
+    {
+        return track.Step(dt);
+    }
+
+};
+
+void bind_track(pybind11::module &m)
+{
+    py::class_<BindTrackUkf>(m, "BindTrack")
+        .def(py::init<>())
+        .def("step",(Eigen::MatrixXd(BindTrackUkf::*)(Eigen::MatrixXd&)) &BindTrackUkf::step)
+        .def("step",(Eigen::MatrixXd(BindTrackUkf::*)(double)) &BindTrackUkf::step);
+        
+}

--- a/bindpy/bind_track.h
+++ b/bindpy/bind_track.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/eigen.h>
+#include "track.h"
+#include "models.h"
+#include "ukf.h"
+
+void bind_track(pybind11::module &m);

--- a/bindpy/bind_ukf.cpp
+++ b/bindpy/bind_ukf.cpp
@@ -7,8 +7,7 @@ class BindUkf
 private:
 
     UnscentedKalmanfilter<Eigen::MatrixXd, FuncConstVel,FuncMeasSph> ukf;
-
-
+ 
 public:
     
         BindUkf(Eigen::MatrixXd state,

--- a/bindpy/bind_ukf.h
+++ b/bindpy/bind_ukf.h
@@ -5,5 +5,4 @@
 #include <pybind11/eigen.h>
 #include "ukf.h"
 
-
 void bind_ukf(pybind11::module &m);

--- a/bindpy/bindings.cpp
+++ b/bindpy/bindings.cpp
@@ -1,6 +1,7 @@
 #include "bind_ukf.h"
-
+#include "bind_track.h"
 PYBIND11_MODULE(estimator, m) {
     bind_ukf(m);
+    bind_track(m);
     // bind_ekf(m);
 }

--- a/scripts/imitatior.py
+++ b/scripts/imitatior.py
@@ -13,7 +13,6 @@ dt = 6.0
 pd = 0.9
 R = np.diag([1.0, 1e-4, 1e-4]) # в рад задается
 plt.rcParams['figure.figsize'] = [10, 6]
-fig = make_subplots(rows=1, cols=1, specs=[[{'type': 'scatter3d'}]])
 fig2 = make_subplots(rows=1, cols=1, specs=[[{'type': 'scatter3d'}]])
 
 class Target():
@@ -117,14 +116,11 @@ def make_pass(X_true_data, pd): #при pd = 1 пропусков не буде�
         if uniform.rvs() < (1 - pd):
            xtmp [:,i] = 0
     pass_columns = np.all(xtmp == 0, axis=0)
-    # print ("xtmp",xtmp)
-    # print("X_true_data_Notpass",X_true_data)
-    # print("pass",pass_columns)
     return xtmp, pass_columns
 
 
 def make_true (tg1): 
-    n = 10 # количество измерении
+    n = 100 # количество измерении
 
     x1=[];y1=[];z1=[]; vx1=[];vy1=[];vz1=[] 
     for i in range(n):
@@ -136,16 +132,7 @@ def make_true (tg1):
         vy1.append(state1['vy'])
         vz1.append(state1['vz'])
 
-    X_true_data_not_pass = np.array([x1,vx1,y1,vy1,z1,vz1])      
- 
-    # Создаем трехмерный scatter plot для массива
-    # scatter1 = go.Scatter3d(x=X_true_data_not_pass[0], y=X_true_data_not_pass[2], z=X_true_data_not_pass[4], mode='markers+lines', marker=dict(size=3, color='blue'), name='X_true_data')
-    # fig.add_trace(scatter1)
-
-    # # Обновляем параметры макета
-    # fig.update_layout(scene=dict(aspectmode="cube"))
-    # fig.show()
-    
+    X_true_data_not_pass = np.array([x1,vx1,y1,vy1,z1,vz1])        
 
     return (X_true_data_not_pass)
 
@@ -156,14 +143,12 @@ X_true_data_with_pass, pass_index = make_pass(X_true_data_not_pass, pd)
 
 with_pass = remove_zero_columns(X_true_data_with_pass)
 # Создаем трехмерный scatter plot для массива
-# scatter2 = go.Scatter3d(x=with_pass[0], y=with_pass[2], z=with_pass[4], mode='markers+lines', marker=dict(size=3, color='blue'), name='X_true_data')
-# fig2.add_trace(scatter2)
+scatter2 = go.Scatter3d(x=with_pass[0], y=with_pass[2], z=with_pass[4], mode='markers+lines', marker=dict(size=3, color='blue'), name='X_true_data')
+fig2.add_trace(scatter2)
 
-# # Обновляем параметры макета
-# fig2.update_layout(scene=dict(aspectmode="cube"))
-# fig2.show()
-
-
+# Обновляем параметры макета
+fig2.update_layout(scene=dict(aspectmode="cube"))
+fig2.show()
 
 
 # ================= Блок 2 =================
@@ -194,7 +179,7 @@ X_true_plus_ProcNoise_not_pass = X_true_plus_ProcNoise_with_pass
 X_true_plus_ProcNoise_not_pass[:,pass_index] = 0
 X_true_plus_ProcNoise_not_pass = X_true_plus_ProcNoise_with_pass[:, ~pass_index] # вырезаю пропуски, что построить график
 # print("X_true_plus_ProcNoise_not_pass" , X_true_plus_ProcNoise_not_pass)
-plt.plot(X_true_plus_ProcNoise_not_pass[0],X_true_plus_ProcNoise_not_pass[2], label='X_true_plus_ProcNoise', linestyle='-', marker='o')
+plt.plot(X_true_plus_ProcNoise_not_pass[0],X_true_plus_ProcNoise_not_pass[2], label='X_true_plus_ProcNoise+pass', linestyle='-', marker='o')
 plt.legend()
 # print("X_true+noise", X_true_plus_ProcNoise)
 
@@ -241,17 +226,18 @@ plt.legend()
 k = 1.0
 def estimate (Z):
 
-
     Z_cart = Zsph2cart(Z)
     X0 = np.vstack([Z_cart[0,0], 0., Z_cart[1,0], 0., Z_cart[2,0], 0.]) # инициализируем вектор состояния, равный первому измерению
 
-    ukf = estimator.BindUkf(X0,dt,Qp,R,k) #инициал. фильтра
+    ukf = estimator.BindTrackUkf(X0,dt,Qp,R,k) #инициал. фильтра
     X_c = np.empty((len(X0), 0))
     for i in range (Z.shape[1]-1):
-        _ = ukf.predictUkf()
-        X = ukf.correctUkf(Z[:,i+1])
+        if np.all(Z[:,i+1] == 0):
+            X = ukf.step(dt)
+            X_c = np.append(X_c,X,axis=1)
+            continue
+        X = ukf.step(Z[:,i+1])
         X_c = np.append(X_c,X,axis=1)
-     
     return X_c 
 
 X_c = estimate(Z)
@@ -293,7 +279,7 @@ def calc_err(X):
 from tqdm import tqdm
 
 def calc_std_err(X):
-    print ("X", X)
+    # print ("X", X)
     num_iterations = 2000
     var_err = np.zeros((X.shape[0], X.shape[1]-1))
 

--- a/scripts/imitatior.py
+++ b/scripts/imitatior.py
@@ -241,6 +241,7 @@ plt.legend()
 k = 1.0
 def estimate (Z):
 
+
     Z_cart = Zsph2cart(Z)
     X0 = np.vstack([Z_cart[0,0], 0., Z_cart[1,0], 0., Z_cart[2,0], 0.]) # инициализируем вектор состояния, равный первому измерению
 
@@ -280,7 +281,6 @@ def calc_err(X):
 
     Xn = add_process_noise(X, Q)
     X_pass, pass_id = make_pass(Xn,pd)
-    print("X_pass",X_pass)
     Zn = do_measurement(X_pass, R, pass_id)
     X_c = estimate(Zn)
 
@@ -294,7 +294,7 @@ from tqdm import tqdm
 
 def calc_std_err(X):
     print ("X", X)
-    num_iterations = 1
+    num_iterations = 2000
     var_err = np.zeros((X.shape[0], X.shape[1]-1))
 
     for i in tqdm(range(num_iterations)):

--- a/scripts/imitatior.py
+++ b/scripts/imitatior.py
@@ -9,11 +9,12 @@ from IPython.display import clear_output
 import random
 import estimator
 
-# dt = 6.0
 dt = 6.0
+pd = 0.9
 R = np.diag([1.0, 1e-4, 1e-4]) # в рад задается
 plt.rcParams['figure.figsize'] = [10, 6]
 fig = make_subplots(rows=1, cols=1, specs=[[{'type': 'scatter3d'}]])
+fig2 = make_subplots(rows=1, cols=1, specs=[[{'type': 'scatter3d'}]])
 
 class Target():
     """
@@ -90,46 +91,83 @@ class Target():
         return {k:self.targetState[k] for k in self.targetState.keys()}
     
 
+
+
 # =============== Блок 1 ===================
     
 # ИНИЦИАЛИЗАЦИЯ МОДЕЛИ ДВИЖЕНИЯ
 tg1 = Target()
-tg1.init_state({'x':-500.0,'y':0.0,'z':0.0, 'vx':-200.0,'vy':0.0,'vz':0.0}) # к ключам добавить ax и ay будет модель CA
+tg1.init_state({'x':500.0,'y':0.0,'z':0.0, 'vx':200.0,'vy':0.0,'vz':0.0}) # к ключам добавить ax и ay будет модель CA
 #tg1.init_process_noise({'ax':0.0,'ay':0.0}) # при нулях ax и ay воздействия на цель не будет. будет прямая траектория.
 
-def plot_xy(tg1, Pd = 1.0, xmk=[], ymk=[]): #при pd = 1 пропусков не будет
-    n = 100 # количество измерении
+
+def remove_zero_columns(arr):
+
+    zero_columns = np.all(arr == 0, axis=0)
+        
+    # Удаляем столбцы, заполненные нулями
+    arr = arr[:, ~zero_columns]
+        
+    return arr
+
+def make_pass(X_true_data, pd): #при pd = 1 пропусков не будет
+    xtmp = X_true_data.copy()
+    
+    for i in range (2,xtmp.shape[1]):
+        if uniform.rvs() < (1 - pd):
+           xtmp [:,i] = 0
+    pass_columns = np.all(xtmp == 0, axis=0)
+    # print ("xtmp",xtmp)
+    # print("X_true_data_Notpass",X_true_data)
+    # print("pass",pass_columns)
+    return xtmp, pass_columns
+
+
+def make_true (tg1): 
+    n = 10 # количество измерении
 
     x1=[];y1=[];z1=[]; vx1=[];vy1=[];vz1=[] 
     for i in range(n):
         state1 = tg1.CV()
-        if uniform.rvs() > (1 - Pd):
-            x1.append(state1['x'])
-            y1.append(state1['y'])
-            z1.append(state1['z'])
-            vx1.append(state1['vx'])
-            vy1.append(state1['vy'])
-            vz1.append(state1['vz'])
+        x1.append(state1['x'])
+        y1.append(state1['y'])
+        z1.append(state1['z'])
+        vx1.append(state1['vx'])
+        vy1.append(state1['vy'])
+        vz1.append(state1['vz'])
 
-    X_true_data = np.array([x1,vx1,y1,vy1,z1,vz1])        
-    # print(X_true_data)
-
-
+    X_true_data_not_pass = np.array([x1,vx1,y1,vy1,z1,vz1])      
+ 
     # Создаем трехмерный scatter plot для массива
-    # scatter1 = go.Scatter3d(x=X_true_data[0], y=X_true_data[2], z=X_true_data[4], mode='markers+lines', marker=dict(size=3, color='blue'), name='X_true_data')
+    # scatter1 = go.Scatter3d(x=X_true_data_not_pass[0], y=X_true_data_not_pass[2], z=X_true_data_not_pass[4], mode='markers+lines', marker=dict(size=3, color='blue'), name='X_true_data')
     # fig.add_trace(scatter1)
 
     # # Обновляем параметры макета
     # fig.update_layout(scene=dict(aspectmode="cube"))
     # fig.show()
+    
 
-    return (x1,y1,z1,X_true_data)
+    return (X_true_data_not_pass)
 
-x,y,z, X_true_data = plot_xy(tg1,1)
+X_true_data_not_pass = make_true(tg1)
+
+X_true_data_with_pass, pass_index = make_pass(X_true_data_not_pass, pd)
+
+
+with_pass = remove_zero_columns(X_true_data_with_pass)
+# Создаем трехмерный scatter plot для массива
+# scatter2 = go.Scatter3d(x=with_pass[0], y=with_pass[2], z=with_pass[4], mode='markers+lines', marker=dict(size=3, color='blue'), name='X_true_data')
+# fig2.add_trace(scatter2)
+
+# # Обновляем параметры макета
+# fig2.update_layout(scene=dict(aspectmode="cube"))
+# fig2.show()
+
+
 
 
 # ================= Блок 2 =================
-
+# создание истинной зашумленной траектории
 process_var = 0.5
 Qp = np.diag([process_var, process_var, process_var])
 G = np.array([[dt**2/2,  0.0,         0.0],
@@ -142,13 +180,23 @@ Q = G@Qp@G.T
 
 
 def add_process_noise(X, Var):
-    X_true_plus_noise = X + np.sqrt(Var) @ np.random.normal(loc=0, scale=1.0, size=(X.shape[0], X.shape[1]))
-    return X_true_plus_noise
+    X_true_plus_ProcNoise = X + np.sqrt(Var) @ np.random.normal(loc=0, scale=1.0, size=(X.shape[0], X.shape[1]))
+    return X_true_plus_ProcNoise
 
-X_true_plus_noise = add_process_noise(X_true_data, Q)
-plt.plot(X_true_plus_noise[0],X_true_plus_noise[2], label='X_true_plus_ProcNoise', linestyle='-', marker='o')
+X_true_plus_ProcNoise = add_process_noise(X_true_data_not_pass, Q) # движение цели по модели
+
+X_true_plus_ProcNoise_with_pass = add_process_noise(X_true_data_with_pass, Q) # движение цели, но с пропусками
+
+#=================================================================
+#построение графика истинной зашумленной траектории с пропусками
+
+X_true_plus_ProcNoise_not_pass = X_true_plus_ProcNoise_with_pass
+X_true_plus_ProcNoise_not_pass[:,pass_index] = 0
+X_true_plus_ProcNoise_not_pass = X_true_plus_ProcNoise_with_pass[:, ~pass_index] # вырезаю пропуски, что построить график
+# print("X_true_plus_ProcNoise_not_pass" , X_true_plus_ProcNoise_not_pass)
+plt.plot(X_true_plus_ProcNoise_not_pass[0],X_true_plus_ProcNoise_not_pass[2], label='X_true_plus_ProcNoise', linestyle='-', marker='o')
 plt.legend()
-# print("X_true+noise", X_true_plus_noise)
+# print("X_true+noise", X_true_plus_ProcNoise)
 
 
 # ================= Блок 3 =====================
@@ -161,31 +209,39 @@ def Zsph2cart(Z):
     Z_cart = np.vstack((x,y,z))
     return Z_cart
 
-def do_measurement(X_plusProcNoise,R):
+def do_measurement(X_plusProcNoise,R, pass_index):
+
+    X_plusProcNoise[:, pass_index] = 0
     r_true_with_noise = np.sqrt(np.array(X_plusProcNoise[0])**2 + np.array(X_plusProcNoise[2])**2 + np.array(X_plusProcNoise[4])**2)
     az_true_with_noise = np.arctan2(np.array(X_plusProcNoise[2]),np.array(X_plusProcNoise[0])) # Азимут
     um_true_with_noise = np.arctan2(np.array(X_plusProcNoise[4]),np.sqrt(np.array(X_plusProcNoise[0])**2+np.array(X_plusProcNoise[2])**2)) # Угол места
+
     Zm = np.zeros((R.shape[0], X_plusProcNoise.shape[1]))
     for i in range(Zm.shape[1]):
         Zm[0,i] = r_true_with_noise[i]
         Zm[1,i] = az_true_with_noise[i]
         Zm[2,i] = um_true_with_noise[i]
-    # print ("zm=", Zm)
-    Z_plus_noise = Zm + np.sqrt(R) @ np.random.normal(loc=0, scale=math.sqrt(1.0), size=(Zm.shape[0], Zm.shape[1]))
-    return Z_plus_noise
-Z = do_measurement (X_true_plus_noise,R)
 
-Zc = Zsph2cart(Z)
+    Z_plus_noise = Zm + np.sqrt(R) @ np.random.normal(loc=0, scale=math.sqrt(1.0), size=(Zm.shape[0], Zm.shape[1]))
+    Z_plus_noise[:, pass_index] = 0
+
+    return Z_plus_noise
+
+Z = do_measurement (X_true_plus_ProcNoise_with_pass, R, pass_index)
+
+
+#==================Отрисовка==================
+Z_not_pass = Z
+Z_not_pass = remove_zero_columns(Z_not_pass)
+Zc = Zsph2cart(Z_not_pass)
 plt.plot(Zc[0],Zc[1], label='do_meas', linestyle='-', marker='x')
 plt.legend()
-# print ("Z=", Z)
-
 
 # ================= Блок 4 ===================
 k = 1.0
 def estimate (Z):
-    Z_cart = Zsph2cart(Z)
 
+    Z_cart = Zsph2cart(Z)
     X0 = np.vstack([Z_cart[0,0], 0., Z_cart[1,0], 0., Z_cart[2,0], 0.]) # инициализируем вектор состояния, равный первому измерению
 
     ukf = estimator.BindUkf(X0,dt,Qp,R,k) #инициал. фильтра
@@ -193,25 +249,27 @@ def estimate (Z):
     for i in range (Z.shape[1]-1):
         _ = ukf.predictUkf()
         X = ukf.correctUkf(Z[:,i+1])
-
         X_c = np.append(X_c,X,axis=1)
      
     return X_c 
 
 X_c = estimate(Z)
 
-def err1(X_c,X_true_plus_noise):
-    er = X_c[:,:] - X_true_plus_noise [:,1:]
+def err1(X_c,X_true_plus_ProcNoise):
+
+    er = X_c[:,:] - X_true_plus_ProcNoise [:,1:]
     return er
-e = err1(X_c,X_true_plus_noise)
-print("e =", e[0]) #Распечатка ошибок по Х одной трассы
+
+e = err1(X_c, X_true_plus_ProcNoise)
+# print("e =", e[0]) #Распечатка ошибок по Х одной трассы
 
 
+#==================Отрисовка==================
 Z_cart = Zsph2cart(Z)
 plt.figure()
 plt.plot(X_c[0], X_c[2], label='Correct', marker='o')
-plt.plot(X_true_plus_noise[0],X_true_plus_noise[2], label='truth', marker='x')
-plt.plot(Z_cart[0], Z_cart[1], label='Meas')
+plt.plot(X_true_plus_ProcNoise[0],X_true_plus_ProcNoise[2], label='truth', marker='x')
+plt.plot(Zc[0], Zc[1], label='Meas',marker='o')
 plt.legend()
 
 
@@ -219,9 +277,13 @@ plt.legend()
 # СБОР СТАТИСТИКИ
 
 def calc_err(X):
+
     Xn = add_process_noise(X, Q)
-    Zn = do_measurement(Xn, R)
+    X_pass, pass_id = make_pass(Xn,pd)
+    print("X_pass",X_pass)
+    Zn = do_measurement(X_pass, R, pass_id)
     X_c = estimate(Zn)
+
     err = X_c[:,:] - Xn [:,1:] # ошибка вычисляется со второго столбца.
 
     # print("ошибка в статистике calc_err",err[0])
@@ -231,7 +293,8 @@ def calc_err(X):
 from tqdm import tqdm
 
 def calc_std_err(X):
-    num_iterations = 2000
+    print ("X", X)
+    num_iterations = 1
     var_err = np.zeros((X.shape[0], X.shape[1]-1))
 
     for i in tqdm(range(num_iterations)):
@@ -239,39 +302,38 @@ def calc_std_err(X):
         var_err += err ** 2
 
     var_err /= num_iterations
-    # print("ошибка в статистике std_err",np.sqrt(var_err)[0])
     return np.sqrt(var_err)
 
-std_err = calc_std_err(X_true_data)
+std_err = calc_std_err(X_true_data_not_pass)
 
 plt.figure()
 plt.subplot(6, 1, 1)
-plt.plot((np.arange(len(std_err[0, :]))+1)*dt, std_err[0, :].T)
+plt.plot((np.arange(len(std_err[0, :]))+2)*dt, std_err[0, :].T)
 plt.xlabel('Time,s')
 plt.ylabel('std_x, met')
 plt.grid(True)
 plt.subplot(6, 1, 2)
-plt.plot((np.arange(len(std_err[1, :]))+1)*dt, std_err[1, :].T)
+plt.plot((np.arange(len(std_err[1, :]))+2)*dt, std_err[1, :].T)
 plt.grid(True)
 plt.xlabel('Time,s')
 plt.ylabel('std_vx, m/s')
 plt.subplot(6, 1, 3)
-plt.plot((np.arange(len(std_err[2, :]))+1)*dt, std_err[2, :].T)
+plt.plot((np.arange(len(std_err[2, :]))+2)*dt, std_err[2, :].T)
 plt.grid(True)
 plt.xlabel('Time,s')
 plt.ylabel('std_y, met')
 plt.subplot(6, 1, 4)
-plt.plot((np.arange(len(std_err[3, :]))+1)*dt, std_err[3, :].T)
+plt.plot((np.arange(len(std_err[3, :]))+2)*dt, std_err[3, :].T)
 plt.grid(True)
 plt.xlabel('Time,s')
 plt.ylabel('std_vy, m/s')
 plt.subplot(6, 1, 5)
-plt.plot((np.arange(len(std_err[4, :]))+1)*dt, std_err[4, :].T)
+plt.plot((np.arange(len(std_err[4, :]))+2)*dt, std_err[4, :].T)
 plt.grid(True)
 plt.xlabel('Time,s')
 plt.ylabel('std_z, met')
 plt.subplot(6, 1, 6)
-plt.plot((np.arange(len(std_err[5, :]))+1)*dt, std_err[5, :].T)
+plt.plot((np.arange(len(std_err[5, :]))+2)*dt, std_err[5, :].T)
 plt.grid(True)
 plt.xlabel('Time,s')
 plt.ylabel('std_vz, m/s')

--- a/src/include/models.h
+++ b/src/include/models.h
@@ -2,13 +2,26 @@
 #include "utils.h"
 #define ENUM_TO_INT(x) static_cast<int>(x)
 
-enum class SizeMat {
+enum class SizeMat
+{
     ROW1 = 1,
     ROW3 = 3,
     ROW6 = 6,
     COL1 = 1,
     COL6 = 6
 };
+enum class MeasPositionMat
+{
+    AZ = 1,
+    EL = 2
+};
+enum class CoordPositionMat
+{
+    X = 0,
+    Y = 2,
+    Z = 4
+};
+
 template <class M>
 struct FuncConstVel
 {
@@ -41,7 +54,6 @@ struct FuncConstVel
             0.0, 0.0, 0.0, 0.0, 1.0, T,
             0.0, 0.0, 0.0, 0.0, 0.0, 1.0;
 
-        //------------ЭКСТРАПОЛЯЦИЯ СИГМА-ВЕКТОРОВ-----------------
         std::vector<M> Xue(Xu.size());
 
         for (int i = 0; i < Xu.size(); i++)
@@ -53,47 +65,48 @@ struct FuncConstVel
     }
 };
 
-
-
 template <class M>
 struct FuncMeasSph
 { 
         M operator()(const M X, M Z)
     {   
-        SizeMat rows = SizeMat::ROW3;
-        SizeMat cols = SizeMat::COL1;
+        MeasPositionMat azPos = MeasPositionMat::AZ;
 
-        double range = sqrt(pow(X(0, 0), 2) + pow(X(2, 0), 2) + pow(X(4, 0), 2));
-        double az = atan2(X(2, 0), X(0, 0));
-        double el = atan2(X(4, 0), sqrt(pow(X(0, 0), 2) + pow(X(2, 0), 2)));
+        CoordPositionMat xPos = CoordPositionMat::X;
+        CoordPositionMat yPos = CoordPositionMat::Y;
+        CoordPositionMat zPos = CoordPositionMat::Z;
+
+        double range = sqrt(pow(X(ENUM_TO_INT(xPos), 0), 2) + pow(X(ENUM_TO_INT(yPos), 0), 2) + pow(X(ENUM_TO_INT(zPos), 0), 2));
+        double az = atan2(X(ENUM_TO_INT(yPos), 0), X(ENUM_TO_INT(xPos), 0));
+        double el = atan2(X(ENUM_TO_INT(zPos), 0), sqrt(pow(X(ENUM_TO_INT(xPos), 0), 2) + pow(X(ENUM_TO_INT(yPos), 0), 2)));
         
-        az =  Z(1,0) + Utils<M>::ComputeAngleDifference(az, Z(1,0));
+        az =  Z(ENUM_TO_INT(azPos),0) + Utils<M>::ComputeAngleDifference(az, Z(ENUM_TO_INT(azPos),0));
         M z (Z.rows(), Z.cols());
         z << range,az,el;
         return z;
     }
 
-
     std::vector<M> operator()(const std::vector<M> Xue, M Z)
     {   
-        SizeMat rows = SizeMat::ROW3;
-        SizeMat cols = SizeMat::COL1;
+        MeasPositionMat azPos = MeasPositionMat::AZ;
+
+        CoordPositionMat xPos = CoordPositionMat::X;
+        CoordPositionMat yPos = CoordPositionMat::Y;
+        CoordPositionMat zPos = CoordPositionMat::Z;
+
         std::vector<M> Zue(Xue.size());
         for (int i = 0; i < Xue.size(); i++)
         {
-            double range = sqrt(pow(Xue[i](0, 0), 2) + pow(Xue[i](2, 0), 2) + pow(Xue[i](4, 0), 2));
-            double az = atan2(Xue[i](2, 0), Xue[i](0, 0));
-            double el = atan2(Xue[i](4, 0), sqrt(pow(Xue[i](0, 0), 2) + pow(Xue[i](2, 0), 2)));
+            double range = sqrt(pow(Xue[i](ENUM_TO_INT(xPos), 0), 2) + pow(Xue[i](ENUM_TO_INT(yPos), 0), 2) + pow(Xue[i](ENUM_TO_INT(zPos), 0), 2));
+            double az = atan2(Xue[i](ENUM_TO_INT(yPos), 0), Xue[i](ENUM_TO_INT(xPos), 0));
+            double el = atan2(Xue[i](ENUM_TO_INT(zPos), 0), sqrt(pow(Xue[i](ENUM_TO_INT(xPos), 0), 2) + pow(Xue[i](ENUM_TO_INT(yPos), 0), 2)));
 
-            M zTmp(ENUM_TO_INT(rows), ENUM_TO_INT(cols));
+            M zTmp(Z.rows(), Z.cols());
             zTmp << range, az, el;
             Zue[i] = zTmp;
 
-            Zue[i](1,0) =  Z(1,0) + Utils<M>::ComputeAngleDifference(Zue[i](1,0), Z(1,0));
+            Zue[i](ENUM_TO_INT(azPos),0) =  Z(ENUM_TO_INT(azPos),0) + Utils<M>::ComputeAngleDifference(Zue[i](ENUM_TO_INT(azPos),0), Z(ENUM_TO_INT(azPos),0));
         }
         return Zue;
     }
 };
-
-
-    

--- a/src/include/storage.h
+++ b/src/include/storage.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <vector>
+#include "track.h"
+
+struct Storage
+{
+
+    void getTrack();
+    void putTrack();
+
+    private:
+    std::vector<Track> tracks;
+    std::vector<Track> usedTracks;
+    std::vector<Track> UnusedTracks;
+
+};

--- a/src/include/track.h
+++ b/src/include/track.h
@@ -5,6 +5,9 @@
 template <class M, class TypeEstimator>
 struct Track
 {
+
+    Track(const M &X, double t, const M &procNoise, const M &measNoiseMatRadian, double koef) : estimator(X, t, procNoise, measNoiseMatRadian, koef) {}
+
     M Step(M &meas)
     {
         M xe = estimator.predict();
@@ -13,20 +16,21 @@ struct Track
     }
     M Step(double dt)
     {
-        M xe = estimator.predict();
-        estimator.UKfilterMath.X = estimator.UKfilterMath.predictStruct.Xe;
+        auto FilterMath = estimator.getFilterMath();
+        FilterMath.X = estimator.predict();
 
         try
         {
-            Utils<M>::СheckingСonditionsMat(estimator.UKfilterMath.predictStruct.Pe)
+            Utils<M>::СheckingСonditionsMat(FilterMath.predictStruct.Pe);
         }
         catch (const std::runtime_error &e)
         {
             std::cerr << e.what() << '\n';
         }
 
-        estimator.UKfilterMath.P = estimator.UKfilterMath.predictStruct.Pe;
-        return estimator.UKfilterMath.P;
+        FilterMath.P = FilterMath.predictStruct.Pe;
+        estimator.setFilterMath(FilterMath);
+        return FilterMath.X;
     }
 
 private:

--- a/src/include/track.h
+++ b/src/include/track.h
@@ -1,0 +1,34 @@
+
+#pragma once
+#include "utils.h"
+
+template <class M, class TypeEstimator>
+struct Track
+{
+    M Step(M &meas)
+    {
+        M xe = estimator.predict();
+        M x = estimator.correct(meas);
+        return x;
+    }
+    M Step(double dt)
+    {
+        M xe = estimator.predict();
+        estimator.UKfilterMath.X = estimator.UKfilterMath.predictStruct.Xe;
+
+        try
+        {
+            Utils<M>::СheckingСonditionsMat(estimator.UKfilterMath.predictStruct.Pe)
+        }
+        catch (const std::runtime_error &e)
+        {
+            std::cerr << e.what() << '\n';
+        }
+
+        estimator.UKfilterMath.P = estimator.UKfilterMath.predictStruct.Pe;
+        return estimator.UKfilterMath.P;
+    }
+
+private:
+    TypeEstimator estimator;
+};

--- a/src/include/ukf.h
+++ b/src/include/ukf.h
@@ -30,7 +30,7 @@ struct UnscentedKalmanfilter
     public:
 
     M predict();
-    M correct(const M& Z = M::Zero());
+    M correct(const M& Z);
 
     UnscentedKalmanfilter(const M& X, double t, const M& procNoise, const M& measNoiseMatRadian ,double koef): 
                                                                                                             T(t),UKfilterMath(X,measNoiseMatRadian, procNoise, t, koef){}
@@ -56,7 +56,7 @@ M UnscentedKalmanfilter<M, StateFunc, MeasurementFunc>::predict()
     ExtrapolatedSigmaVectors = stateFunc(sigmaVectors, T);
     UKfilterMath.doExtrapolatedStateVector(ExtrapolatedSigmaVectors, weightVectors);
     UKfilterMath.doCovMatExtrapolatedStateVector(ExtrapolatedSigmaVectors, weightVectors);
-
+    
     return UKfilterMath.predictStruct.Xe;
 }
 
@@ -65,14 +65,6 @@ template <class M,
           template <typename> class MeasurementFunc>
 M UnscentedKalmanfilter<M, StateFunc, MeasurementFunc>::correct(const M& Z)
 {   
-
-    if (Z.isZero())
-    {   
-        UKfilterMath.X = UKfilterMath.predictStruct.Xe;
-        UKfilterMath.P = UKfilterMath.predictStruct.Pe; // проверка на симметричность
-        return UKfilterMath.X;
-    }
-
     std::vector<M> ExtrapolatedSigmaVectorsSph = measFunc(ExtrapolatedSigmaVectors, Z);
     UKfilterMath.doExtrapolatedStateVectorSph(ExtrapolatedSigmaVectorsSph, weightVectors);
     UKfilterMath.doCovMatExtrapolatedStateVectorSph(ExtrapolatedSigmaVectorsSph, weightVectors);
@@ -81,5 +73,3 @@ M UnscentedKalmanfilter<M, StateFunc, MeasurementFunc>::correct(const M& Z)
     M correctCov = UKfilterMath.correctCov();
     return correctState;
 }
-
-

--- a/src/include/ukf.h
+++ b/src/include/ukf.h
@@ -31,9 +31,12 @@ struct UnscentedKalmanfilter
 
     M predict();
     M correct(const M& Z);
+    UnscentedKalmanFilterMath<M> getFilterMath(); 
+    void setFilterMath(UnscentedKalmanFilterMath<M> &);
 
     UnscentedKalmanfilter(const M& X, double t, const M& procNoise, const M& measNoiseMatRadian ,double koef): 
                                                                                                             T(t),UKfilterMath(X,measNoiseMatRadian, procNoise, t, koef){}
+                                                                                                           
 };
 
 template <class M,
@@ -72,4 +75,20 @@ M UnscentedKalmanfilter<M, StateFunc, MeasurementFunc>::correct(const M& Z)
     M correctState = UKfilterMath.correctState(Z);
     M correctCov = UKfilterMath.correctCov();
     return correctState;
+}
+
+template <class M,
+          template <typename> class StateFunc,
+          template <typename> class MeasurementFunc>
+UnscentedKalmanFilterMath<M> UnscentedKalmanfilter<M, StateFunc, MeasurementFunc>::getFilterMath()
+{
+    return UKfilterMath;
+}
+
+template <class M,
+          template <typename> class StateFunc,
+          template <typename> class MeasurementFunc>
+void UnscentedKalmanfilter<M, StateFunc, MeasurementFunc>:: setFilterMath(UnscentedKalmanFilterMath<M> &newUkfilterMath)
+{
+    UKfilterMath = newUkfilterMath;
 }

--- a/src/include/ukfMath.h
+++ b/src/include/ukfMath.h
@@ -50,6 +50,7 @@ UnscentedKalmanFilterMath<M>::UnscentedKalmanFilterMath(const M &state, const M 
 template <class M>
 void UnscentedKalmanFilterMath<M>::make_P_cart()
 {  
+    
 
     if (P.isZero())
     {
@@ -86,6 +87,7 @@ std::vector<M> UnscentedKalmanFilterMath<M>::doSigmaVectors()
     for (int i = 0; i < n; i++)
     {  
         Xu[i + n + 1] = X - U.col(i);
+
     }
     
     return Xu;
@@ -118,7 +120,7 @@ void UnscentedKalmanFilterMath<M>::doExtrapolatedStateVector(std::vector<M> &Xue
     {
         predictStruct.Xe = predictStruct.Xe + w[i] * Xue[i];
     }
-
+    
 }
 
 template <class M>
@@ -145,7 +147,7 @@ void UnscentedKalmanFilterMath<M>::doExtrapolatedStateVectorSph(const std::vecto
 
     predictStruct.Ze = M::Zero(Zue[0].rows(),Zue[0].cols());
     for (int i = 0; i < Zue.size(); i++)
-    {   
+    {
         predictStruct.Ze = predictStruct.Ze + w[i] * Zue[i];
     }
 }
@@ -185,11 +187,8 @@ template <class M>
 M UnscentedKalmanFilterMath<M>::correctState(const M& Z)
     
 {   
-    // predictStruct.Ze(1,0) = Z(1,0) + Utils<M>::ComputeAngleDifference(predictStruct.Ze(1,0), Z(1,0));
-
     correctStruct.X = predictStruct.Xe + predictStruct.K * (Z - predictStruct.Ze);
     X = correctStruct.X; 
-    // std::cout<< "\ncorrectStruct.X ="<<correctStruct.X<<std::endl;
     return correctStruct.X;
 }
 

--- a/src/include/ukfMath.h
+++ b/src/include/ukfMath.h
@@ -51,7 +51,6 @@ template <class M>
 void UnscentedKalmanFilterMath<M>::make_P_cart()
 {  
     
-
     if (P.isZero())
     {
         M R_sph_deg = Utils<M>::RsphRad2RsphDeg(R_sph_rad);

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Eigen/Dense"
+#include <iostream>
 #include "structs.h"
 
 #define ENUM_TO_INT(x) static_cast<int>(x)

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -159,7 +159,7 @@ bool Utils<M>::СheckingСonditionsMat(const M& P)
     if((P.transpose().isApprox(P, 1e-8)) && (P.llt().info() == Eigen::Success) && (P.determinant() !=0))
         return true;
         else{
-            return false;
+            throw std::runtime_error("СheckingСonditionsMat ERROR");
         }
 }
 template <class M>


### PR DESCRIPTION
Я в имитаторе сделал возможность добавлять пропуски (pd — вероятность обнаружения, задается вверху), а в фильтре, соответственно, обработал эту ситуацию (в случае пропуска подставлял экстраполированную отметку).
Пропуски в имитаторе я обозначал нулевым вектором (0, 0, 0, 0, 0, 0), и, соответственно, если в метод UnscentedKalmanFilter.correct(Z) поступает такой вектор, то это считается пропуском и подставляется экстраполяция. Однако бывает ситуация, что пропуск попадает на 2-ю отметку и, следовательно, я не могу проэкстраполировать и подставить, здесь нужно по-другому обрабатывать. Поэтому пока что я сделал генерацию пропусков, начиная с 3-й отметки.